### PR TITLE
add symbol usage to docs

### DIFF
--- a/lib/observer.rb
+++ b/lib/observer.rb
@@ -111,6 +111,30 @@
 #   Current price: 112
 #   Current price: 79
 #   --- Sun Jun 09 00:10:25 CDT 2002: Price below 80: 79
+#
+# === Usage with procs
+#
+# The +#notify_observers+ method can also be used with +proc+s by using
+# the +:call+ as +func+ parameter.
+#
+# The following example illustrates the use of a lambda:
+#
+#   require 'observer'
+# 
+#   class Ticker
+#     include Observable
+#
+#     def run
+#       # logic to retrieve the price (here 77.0)
+#       changed
+#       notify_observers(77.0)
+#     end
+#   end
+#
+#   ticker = Ticker.new
+#   warner = ->(price) { puts "New price received: #{price}" }
+#   ticker.add_observer(warner, :call)
+#   ticker.run
 module Observable
 
   #


### PR DESCRIPTION
A minor documentation update on how to use the `Observable` module with procs/lambdas. For me this was not obvious at first glance, so I hope this would help others...