### PR TITLE
build: Use bundler-cache to install deps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,6 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
-    - name: Install dependencies
-      run: bundle install
+        bundler-cache: true # Run "bundle install", and cache the result automatically.
     - name: Run test
-      run: rake test
+      run: bundle exec rake test


### PR DESCRIPTION
This PR uses `setup-ruby`'s Bundler installation option instead of a specific run step to install the Gemfile dependencies.

It also runs the tests in the context of the Gemfile (adding `bundler exec` to the test run).